### PR TITLE
feat: Add cx_oceanbase driver support with SQLAlchemy 2.x compatibility

### DIFF
--- a/oceanbase-sqlalchemy-plugin/oceanbase_sqlalchemy/cx_oceanbase.py
+++ b/oceanbase-sqlalchemy-plugin/oceanbase_sqlalchemy/cx_oceanbase.py
@@ -4,12 +4,30 @@ OceanBase dialect for cx_oceanbase driver.
 """
 
 from .cx_oracle import OceanBaseDialect_cx_oracle
+import cx_Oceanbase
 
 
 class OceanBaseDialect_cx_oceanbase(OceanBaseDialect_cx_oracle):
     """
-    OceanBase dialect for cx_oracle driver.
+    OceanBase dialect for cx_oceanbase driver.
     """
 
     name = "oceanbase"
     driver = "cx_oceanbase"
+
+    # SQLAlchemy 2.x compatibility
+    supports_statement_cache = True
+
+    @classmethod
+    def import_dbapi(cls):
+        """SQLAlchemy 2.x recommended method name"""
+        return cx_Oceanbase
+
+    @classmethod
+    def dbapi(cls):
+        """Maintain backward compatibility"""
+        return cx_Oceanbase
+
+
+# Register dialect, similar to SQLAlchemy's cx_oracle.py
+dialect = OceanBaseDialect_cx_oceanbase

--- a/oceanbase-sqlalchemy-plugin/setup.py
+++ b/oceanbase-sqlalchemy-plugin/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="oceanbase-sqlalchemy",
-    version="0.2.0",
+    version="0.3.0",
     description="SQLAlchemy dialect for OceanBase Oracle mode (supports SQLAlchemy 1.3.x and 2.0+)",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description

This PR adds cx_oceanbase driver support to the OceanBase SQLAlchemy plugin with SQLAlchemy 2.x compatibility.

## Key Changes

- Add cx_oceanbase driver support
- Implement SQLAlchemy 2.x compatibility
- Add supports_statement_cache = True for better performance
- Implement import_dbapi and dbapi methods
- Upgrade version from 0.2.0 to 0.3.0

## Technical Details

- Added SQLAlchemy 2.x compatibility support in cx_oceanbase.py
- Implemented standard import_dbapi and dbapi methods
- Added statement cache support for better performance
- Maintained backward compatibility

## Testing

- [ ] Tested SQLAlchemy 1.3.x compatibility
- [ ] Tested SQLAlchemy 2.x compatibility  
- [ ] Tested cx_oceanbase driver connection